### PR TITLE
Update `build` command with `--overwrite` option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@ const TreeSync = require('tree-sync');
 const childProcess = require('child_process');
 const fs = require('fs');
 const WatchDetector = require('watch-detector');
+const rimraf = require('rimraf')
 
 const broccoli = require('./index');
 const messages = require('./messages');
@@ -54,6 +55,7 @@ module.exports = function broccoliCLI(args) {
     .option('--output-path <path>', 'the path to target output folder')
     .option('--watch', 'turn on the watcher')
     .option('--watcher <watcher>', 'select sane watcher mode')
+    .option('--overwrite', 'overwrite the <target> directory')
     .action((outputDir, options) => {
       if (outputDir && options.outputPath) {
         console.error('option --output-path and [target] cannot be passed at same time');
@@ -68,7 +70,11 @@ module.exports = function broccoliCLI(args) {
         outputDir = 'dist';
       }
 
-      guardOutputDir(outputDir);
+      if (options.overwrite && fs.existsSync(outputDir)) {
+        rimraf.sync(outputDir)
+      } else if (fs.existsSync(outputDir)) {
+        guardOutputDir(outputDir);
+      }
 
       const builder = getBuilder({ brocfilePath: options.brocfilePath });
       const Watcher = getWatcher(options.watch);
@@ -156,7 +162,7 @@ function buildWatcherOptions(options) {
 
 function guardOutputDir(outputDir) {
   if (fs.existsSync(outputDir)) {
-    console.error(outputDir + '/ already exists; we cannot build into an existing directory');
+    console.error(outputDir + '/ already exists; we cannot build into an existing directory, provide --overwrite to auto-delete the output directory');
     process.exit(1);
   }
 }

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -203,6 +203,14 @@ describe('cli', function() {
         });
       });
     });
+    context('with param --overwrite', function() {
+      it('removes previous build', function() {
+        fs.mkdirSync('dist');
+        return cli(['node', 'broccoli', 'build', '--output-path', 'dist']).then(() => {
+          chai.expect(exitStub).to.be.calledWith(0);
+        });
+      });
+    });
   });
 
   describe('serve', function() {


### PR DESCRIPTION
This PR adds an `--overwrite` CLI option to the build command.
It's very frustrating to have to remove the output directory, so this fixes that issue.